### PR TITLE
Successful pass of auth token

### DIFF
--- a/Mobile/media_tracker_mobile/lib/providers/auth_provider.dart
+++ b/Mobile/media_tracker_mobile/lib/providers/auth_provider.dart
@@ -9,10 +9,10 @@ class AuthState {
   final String? firstName;
   final String? lastName;
   final String? email;
-  //final String? token;
+  final String? token;
 
   // A computed property that returns true if the user is logged in
-  bool get isLoggedIn => username != null; // && token != null;
+  bool get isLoggedIn => username != null && token != null;
 
   // Constructor for creating an AuthState instance with optional fields
   const AuthState({
@@ -20,7 +20,7 @@ class AuthState {
     this.firstName,
     this.lastName,
     this.email,
-    //this.token,
+    this.token,
   });
 
   // Creates a new AuthState based on the current state,
@@ -30,14 +30,14 @@ class AuthState {
     String? firstName,
     String? lastName,
     String? email,
-    //String? token,
+    String? token,
   }) {
     return AuthState(
       username: username ?? this.username,
       firstName: firstName ?? this.firstName,
       lastName: lastName ?? this.lastName,
       email: email ?? this.email,
-      //token: token ?? this.token,
+      token: token ?? this.token,
     );
   }
 
@@ -56,14 +56,14 @@ class AuthNotifier extends StateNotifier<AuthState> {
     required String firstName,
     required String lastName,
     required String email,
-    //required String token,
+    required String token,
   }) {
     state = AuthState(
       username: username,
       firstName: firstName,
       lastName: lastName,
       email: email,
-      //token: token,
+      token: token,
     );
   }
 

--- a/Mobile/media_tracker_mobile/lib/services/auth_service.dart
+++ b/Mobile/media_tracker_mobile/lib/services/auth_service.dart
@@ -35,13 +35,20 @@ class AuthService {
 
   // Logs in a user by calling a stored procedure and loading their profile info
   Future<bool> login(String username, String password) async {
-    // Call a Postgres RPC (stored procedure) to authenticate user credentials
-    final result = await supabase.rpc(
-      'AuthenticateUser',
-      params: {'usernamevar': username, 'passwordvar': password},
-    );
+    try {
+      // Call the PostgreSQL RPC to authenticate and get a token
+      final result = await supabase.rpc(
+        'auth_user',
+        params: {'username_input': username, 'password_input': password},
+      );
 
-    if (result == true) {
+      // If token is null or empty, login failed
+      if (result == null || result is! String || result.isEmpty) {
+        return false;
+      }
+
+      print('User Authentication Token Result: $result');
+
       // Fetch user's basic profile information (first name, last name, email)
       final userInfo = await supabase
           .from('users')
@@ -72,11 +79,14 @@ class AuthService {
               firstName: userInfo[0]['first_name'] ?? '',
               lastName: userInfo[0]['last_name'] ?? '',
               email: userInfo[0]['email'] ?? '',
+              token: result,
             );
       }
       return true;
+    } catch (e) {
+      print('Login failed: $e');
+      return false;
     }
-    return false;
   }
 
   // Registers a new user using a stored procedure


### PR DESCRIPTION
- Call to the RPC 'auth_user' returns an authentication token from the DB in the form of TEXT instead of a bool.

- Login functions normally