### PR TITLE
Mobile sean

### DIFF
--- a/Mobile/media_tracker_mobile/lib/main.dart
+++ b/Mobile/media_tracker_mobile/lib/main.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:media_tracker_test/screens/account_linking_screen.dart';
+import 'package:media_tracker_test/screens/auth/login_screen.dart';
+import 'package:media_tracker_test/screens/auth/register_screen.dart';
+import 'package:media_tracker_test/screens/media_screen.dart';
 import 'screens/home_screen.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'models/theme.dart' as theme;
@@ -11,12 +15,11 @@ void main() async {
   // This must be done before using any Supabase features in your app.
   await Supabase.initialize(
     url: 'https://hrqakudeaalvgstpupdu.supabase.co/',
-    anonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhycWFrdWRlYWFsdmdzdHB1cGR1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDI5NDk3MzAsImV4cCI6MjA1ODUyNTczMH0.k30q2Ndf-YI0RPGiwllMGJFPYMp5XoRQilCktlMmqFU',
+    anonKey:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhycWFrdWRlYWFsdmdzdHB1cGR1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDI5NDk3MzAsImV4cCI6MjA1ODUyNTczMH0.k30q2Ndf-YI0RPGiwllMGJFPYMp5XoRQilCktlMmqFU',
   );
 
-  runApp(
-    ProviderScope(child: MyApp()),
-  );
+  runApp(ProviderScope(child: MyApp()));
 }
 
 class MyApp extends StatelessWidget {
@@ -26,7 +29,14 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       title: 'Media Tracker',
       theme: theme.themeData,
-      home: HomeScreen(),
+      initialRoute: '/',
+      routes: {
+        '/': (context) => const HomeScreen(),
+        '/login': (context) => const LoginScreen(),
+        '/register': (context) => const RegisterScreen(),
+        '/media': (context) => const MediaScreen(),
+        '/linkAccounts': (context) => AccountLinkingScreen(),
+      },
     );
   }
 }

--- a/Mobile/media_tracker_mobile/lib/providers/auth_provider.dart
+++ b/Mobile/media_tracker_mobile/lib/providers/auth_provider.dart
@@ -16,7 +16,8 @@ class AuthState {
   bool get isLoggedIn => username != null && token != null;
 
   // A computed property that returns true if the user has linked third party API services
-  bool get anyMediaLinked => steamId != null || tmdbSessionId != null || lastFmUsername != null;
+  bool get anyMediaLinked =>
+      steamId != null || tmdbSessionId != null || lastFmUsername != null;
 
   // Constructor for creating an AuthState instance with optional fields
   const AuthState({
@@ -41,6 +42,9 @@ class AuthState {
     String? steamId,
     String? tmdbSessionId,
     String? lastFmUsername,
+    bool clearSteamId = false,
+    bool clearTmdbSessionId = false,
+    bool clearLastFmUsername = false,
   }) {
     return AuthState(
       username: username ?? this.username,
@@ -48,9 +52,11 @@ class AuthState {
       lastName: lastName ?? this.lastName,
       email: email ?? this.email,
       token: token ?? this.token,
-      steamId: steamId ?? this.steamId,
-      tmdbSessionId: tmdbSessionId ?? this.tmdbSessionId,
-      lastFmUsername: lastFmUsername ?? this.lastFmUsername
+      steamId: clearSteamId ? null : (steamId ?? this.steamId),
+      tmdbSessionId:
+          clearTmdbSessionId ? null : (tmdbSessionId ?? this.tmdbSessionId),
+      lastFmUsername:
+          clearLastFmUsername ? null : (lastFmUsername ?? this.lastFmUsername),
     );
   }
 
@@ -72,7 +78,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
     required String token,
     String? steamID,
     String? tmdbSessionId,
-    String? lastFmUsername
+    String? lastFmUsername,
   }) {
     state = AuthState(
       username: username,
@@ -82,7 +88,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
       token: token,
       steamId: steamID,
       tmdbSessionId: tmdbSessionId,
-      lastFmUsername: lastFmUsername
+      lastFmUsername: lastFmUsername,
     );
   }
 
@@ -95,6 +101,22 @@ class AuthNotifier extends StateNotifier<AuthState> {
     ApiServices.steamUserId = "";
     ApiServices.lastFmUser = "";
     ApiServices.tmdbUser = "";
+  }
+
+  // Update methods when a user links third party API service
+  void updateSteamId(String? id) {
+    state = state.copyWith(steamId: id, clearSteamId: id == null);
+  }
+
+  void updateTmdbSessionId(String? id) {
+    state = state.copyWith(tmdbSessionId: id, clearTmdbSessionId: id == null);
+  }
+
+  void updateLastFmUsername(String? username) {
+    state = state.copyWith(
+      lastFmUsername: username,
+      clearLastFmUsername: username == null,
+    );
   }
 }
 

--- a/Mobile/media_tracker_mobile/lib/screens/account_linking_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/account_linking_screen.dart
@@ -24,7 +24,7 @@ class AccountLinkingScreen extends ConsumerWidget {
               linkedValue: auth.steamId,
               onLink: (id) => notifier.updateSteamId(id),
               onUnlink: () => notifier.updateSteamId(null),
-              onEdit: () {}, // Optional: you can handle UI state separately
+              onEdit: () {},
             ),
             LinkAccountCard(
               platformName: 'Last.fm',

--- a/Mobile/media_tracker_mobile/lib/screens/account_linking_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/account_linking_screen.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/auth_provider.dart';
+import 'widgets/link_account_card.dart';
+
+class AccountLinkingScreen extends ConsumerWidget {
+  const AccountLinkingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(authProvider);
+    final notifier = ref.read(authProvider.notifier);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Link Media Accounts'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: Column(
+          children: [
+            LinkAccountCard(
+              platformName: 'Steam',
+              linkedValue: auth.steamId,
+              onLink: (id) => notifier.updateSteamId(id),
+              onUnlink: () => notifier.updateSteamId(null),
+              onEdit: () {}, // Optional: you can handle UI state separately
+            ),
+            LinkAccountCard(
+              platformName: 'Last.fm',
+              linkedValue: auth.lastFmUsername,
+              onLink: (username) => notifier.updateLastFmUsername(username),
+              onUnlink: () => notifier.updateLastFmUsername(null),
+              onEdit: () {},
+            ),
+            LinkAccountCard(
+              platformName: 'TMDB',
+              linkedValue: auth.tmdbSessionId,
+              onLink: (sessionId) => notifier.updateTmdbSessionId(sessionId),
+              onUnlink: () => notifier.updateTmdbSessionId(null),
+              onEdit: () {},
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/Mobile/media_tracker_mobile/lib/screens/media_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/media_screen.dart
@@ -180,14 +180,6 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
 
   Widget _buildBody() {
     final auth = ref.watch(authProvider);
-    // final noAccountsLinked =
-    //     auth.steamId == null &&
-    //     auth.tmdbSessionId == null &&
-    //     auth.lastFmUsername == null;
-
-    // if (noAccountsLinked) {
-    //   return _noMediaLinkedPrompt();
-    // }
 
     switch (_selectedIndex) {
       case 0:

--- a/Mobile/media_tracker_mobile/lib/screens/widgets/link_account_card.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/widgets/link_account_card.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:media_tracker_test/models/theme.dart';
+
+class LinkAccountCard extends ConsumerStatefulWidget {
+  final String platformName;
+  final String? linkedValue;
+  final void Function(String) onLink;
+  final VoidCallback onUnlink;
+  final VoidCallback onEdit;
+
+  const LinkAccountCard({
+    super.key,
+    required this.platformName,
+    required this.linkedValue,
+    required this.onLink,
+    required this.onUnlink,
+    required this.onEdit,
+  });
+
+  @override
+  ConsumerState<LinkAccountCard> createState() => _LinkAccountCardState();
+}
+
+class _LinkAccountCardState extends ConsumerState<LinkAccountCard> {
+  final _controller = TextEditingController();
+  bool _showCredential = false;
+  bool _editMode = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = widget.linkedValue ?? '';
+  }
+
+  @override
+  void didUpdateWidget(covariant LinkAccountCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // When the account is unlinked externally
+    if (oldWidget.linkedValue != widget.linkedValue &&
+        widget.linkedValue == null) {
+      setState(() {
+        _editMode = false;
+        _showCredential = false;
+        _controller.clear();
+      });
+    }
+
+    // When it's linked or updated (still keeps old behavior)
+    if (oldWidget.linkedValue != widget.linkedValue &&
+        widget.linkedValue != null &&
+        !_editMode) {
+      _controller.text = widget.linkedValue!;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    print('[${widget.platformName}] linkedValue: ${widget.linkedValue}');
+    return SizedBox(
+      width: double.infinity, // Ensures full width
+      child: Card(
+        color: const Color.fromARGB(255, 72, 72, 72),
+        margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+        elevation: 4,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                widget.platformName,
+                style: Theme.of(
+                  context,
+                ).textTheme.titleLarge?.copyWith(color: Colors.white),
+              ),
+              const SizedBox(height: 12),
+              AnimatedCrossFade(
+                crossFadeState:
+                    (widget.linkedValue == null || _editMode)
+                        ? CrossFadeState.showFirst
+                        : CrossFadeState.showSecond,
+                duration: const Duration(milliseconds: 200),
+                firstChild: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    TextField(
+                      controller: _controller,
+                      style: const TextStyle(color: Colors.white),
+                      decoration: InputDecoration(
+                        labelText: 'Enter ${widget.platformName} ID',
+                        labelStyle: const TextStyle(color: Colors.white70),
+                        border: const OutlineInputBorder(),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        ElevatedButton.icon(
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: colorPrimary,
+                          ),
+                          icon: const Icon(Icons.link),
+                          label: const Text('Link'),
+                          onPressed: () {
+                            final input = _controller.text.trim();
+                            if (input.isNotEmpty) {
+                              widget.onLink(input);
+                              setState(() {
+                                _editMode = false;
+                                _showCredential = false;
+                              });
+                            }
+                          },
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                secondChild: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      _showCredential
+                          ? widget.linkedValue!
+                          : '••••••••••••••••',
+                      style: const TextStyle(fontSize: 16, color: Colors.white),
+                    ),
+                    const SizedBox(height: 8),
+                    Center(
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          TextButton.icon(
+                            icon: Icon(
+                              _showCredential
+                                  ? Icons.visibility_off
+                                  : Icons.visibility,
+                            ),
+                            label: Text(_showCredential ? 'Hide' : 'Reveal'),
+                            onPressed: () {
+                              setState(() {
+                                _showCredential = !_showCredential;
+                              });
+                            },
+                            style: TextButton.styleFrom(
+                              foregroundColor: Colors.black,
+                            ),
+                          ),
+                          TextButton.icon(
+                            icon: const Icon(Icons.edit),
+                            label: const Text('Edit'),
+                            onPressed: () {
+                              _controller.text = widget.linkedValue!;
+                              setState(() {
+                                _editMode = true;
+                              });
+                              widget.onEdit();
+                            },
+                            style: TextButton.styleFrom(
+                              foregroundColor: Colors.black,
+                            ),
+                          ),
+                          TextButton.icon(
+                            icon: const Icon(Icons.delete),
+                            label: const Text('Unlink'),
+                            onPressed: () {
+                              widget
+                                  .onUnlink(); // ✅ properly calls external clear logic
+                              setState(() {
+                                _showCredential = false;
+                                _editMode = false;
+                                _controller.clear();
+                              });
+                            },
+                            style: TextButton.styleFrom(
+                              foregroundColor: Colors.red,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/Mobile/media_tracker_mobile/lib/screens/widgets/link_account_card.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/widgets/link_account_card.dart
@@ -36,7 +36,11 @@ class _LinkAccountCardState extends ConsumerState<LinkAccountCard> {
   @override
   void didUpdateWidget(covariant LinkAccountCard oldWidget) {
     super.didUpdateWidget(oldWidget);
-    // When the account is unlinked externally
+    // Case 1: The linkedValue was cleared externally (e.g., user unlinked account)
+    // This ensures the UI resets to the "link" state
+    // _editMode is turned off to avoid showing the edit field
+    // _showCredential is turned off so no masked value shows
+    // The controller is cleared so the input field is blank
     if (oldWidget.linkedValue != widget.linkedValue &&
         widget.linkedValue == null) {
       setState(() {
@@ -46,7 +50,10 @@ class _LinkAccountCardState extends ConsumerState<LinkAccountCard> {
       });
     }
 
-    // When it's linked or updated (still keeps old behavior)
+    // Case 2: A new value was linked externally or updated
+    // This ensures the controller reflects the updated linkedValue
+    // Only updates if the user is not currently editing (_editMode == false)
+    // Prevents overwriting any in-progress edits
     if (oldWidget.linkedValue != widget.linkedValue &&
         widget.linkedValue != null &&
         !_editMode) {
@@ -168,7 +175,7 @@ class _LinkAccountCardState extends ConsumerState<LinkAccountCard> {
                             label: const Text('Unlink'),
                             onPressed: () {
                               widget
-                                  .onUnlink(); // ✅ properly calls external clear logic
+                                  .onUnlink(); // properly calls external clear logic
                               setState(() {
                                 _showCredential = false;
                                 _editMode = false;


### PR DESCRIPTION
PR created by Sean

- Created the account linking screen, which will allow user's to link their respective third party services. This only sets the credentials in the auth provider, and does not post this data to the DB.

- If a user with no saved credentials that can be pulled from the DB logs in, the media screen prompts them to link their accounts, and will navigate to the account linking screen.

- Created the link_account_card widget, that handles the creation of each of the three cards to capture user credentials.

- Updated the main.dart file to include routing options for the app