### PR TITLE
3rd Party Service Link

### DIFF
--- a/Mobile/media_tracker_mobile/lib/screens/account_linking_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/account_linking_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:media_tracker_test/services/auth_service.dart';
+import 'package:media_tracker_test/services/user_account_services.dart';
 import '../providers/auth_provider.dart';
 import 'widgets/link_account_card.dart';
 
@@ -12,9 +14,7 @@ class AccountLinkingScreen extends ConsumerWidget {
     final notifier = ref.read(authProvider.notifier);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Link Media Accounts'),
-      ),
+      appBar: AppBar(title: const Text('Link Media Accounts')),
       body: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(vertical: 16),
         child: Column(
@@ -22,21 +22,102 @@ class AccountLinkingScreen extends ConsumerWidget {
             LinkAccountCard(
               platformName: 'Steam',
               linkedValue: auth.steamId,
-              onLink: (id) => notifier.updateSteamId(id),
+              onLink: (id) async {
+                final success = await UserAccountServices()
+                    .savePlatformCredentials(
+                      username: auth.username!,
+                      platformId: 1,
+                      userPlatformId: id,
+                    );
+
+                if (success) {
+                  // Re-fetch the saved value from the DB
+                  final authService = ref.read(authServiceProvider);
+                  final updatedSteamId = await authService.getPlatformID(
+                    auth.username!,
+                    1,
+                  );
+
+                  // Update state only after confirming the value from DB
+                  if (updatedSteamId != null) {
+                    notifier.updateSteamId(updatedSteamId);
+                  }
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Failed to link Steam account.'),
+                    ),
+                  );
+                }
+              },
               onUnlink: () => notifier.updateSteamId(null),
               onEdit: () {},
             ),
             LinkAccountCard(
               platformName: 'Last.fm',
               linkedValue: auth.lastFmUsername,
-              onLink: (username) => notifier.updateLastFmUsername(username),
+              onLink: (username) async {
+                final success = await UserAccountServices()
+                    .savePlatformCredentials(
+                      username: auth.username!,
+                      platformId: 2,
+                      userPlatformId: username,
+                    );
+
+                if (success) {
+                  // Re-fetch the saved value from the DB
+                  final authService = ref.read(authServiceProvider);
+                  final updatedLastfmUsername = await authService.getPlatformID(
+                    auth.username!,
+                    2,
+                  );
+
+                  // Update state only after confirming the value from DB
+                  if (updatedLastfmUsername != null) {
+                    notifier.updateLastFmUsername(updatedLastfmUsername);
+                  }
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Failed to link Last.fm account'),
+                    ),
+                  );
+                }
+              },
               onUnlink: () => notifier.updateLastFmUsername(null),
               onEdit: () {},
             ),
             LinkAccountCard(
               platformName: 'TMDB',
               linkedValue: auth.tmdbSessionId,
-              onLink: (sessionId) => notifier.updateTmdbSessionId(sessionId),
+              onLink: (sessionId) async {
+                final success = await UserAccountServices()
+                    .savePlatformCredentials(
+                      username: auth.username!,
+                      platformId: 3,
+                      userPlatformId: sessionId,
+                    );
+
+                if (success) {
+                  // Re-fetch the saved value from the DB
+                  final authService = ref.read(authServiceProvider);
+                  final updatedTmdbSessionId = await authService.getPlatformID(
+                    auth.username!,
+                    3,
+                  );
+
+                  // Update state only after confirming the value from DB
+                  if (updatedTmdbSessionId != null) {
+                    notifier.updateTmdbSessionId(updatedTmdbSessionId);
+                  }
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Failed to link TMDB account'),
+                    ),
+                  );
+                }
+              },
               onUnlink: () => notifier.updateTmdbSessionId(null),
               onEdit: () {},
             ),

--- a/Mobile/media_tracker_mobile/lib/screens/widgets/drawer_menu.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/widgets/drawer_menu.dart
@@ -28,8 +28,8 @@ class DrawerMenu extends ConsumerWidget {
           ListTile(
             title: const Text('Link Media Services'),
             onTap: () {
-              onSectionSelected(0);
               Navigator.pop(context);
+              Navigator.pushNamed(context, '/linkAccounts');
             },
           ),
           ListTile(

--- a/Mobile/media_tracker_mobile/lib/services/auth_service.dart
+++ b/Mobile/media_tracker_mobile/lib/services/auth_service.dart
@@ -16,7 +16,7 @@ class AuthService {
   ref; // Reference to Riverpod's Ref, used to interact with other providers
   AuthService(this.ref); // Constructor accepting the ref object from Riverpod
 
-  Future<String?> _getPlatformID(String username, int platformId) async {
+  Future<String?> getPlatformID(String username, int platformId) async {
     try {
       final response =
           await Supabase.instance.client
@@ -55,15 +55,15 @@ class AuthService {
 
       // Fetch linked platform IDs (Steam, Last.fm, TMDB) from the useraccounts table
       // If the Steam ID, last.fm ID, or TMDB ID exists, assign them globally via ApiServices
-      final steamID = await _getPlatformID(username, 1);
+      final steamID = await getPlatformID(username, 1);
       if (steamID != null && steamID.isNotEmpty) {
         ApiServices.steamUserId = steamID;
       }
-      final lastfmID = await _getPlatformID(username, 2);
+      final lastfmID = await getPlatformID(username, 2);
       if (lastfmID != null && lastfmID.isNotEmpty) {
         ApiServices.lastFmUser = lastfmID;
       }
-      final tmdbID = await _getPlatformID(username, 3);
+      final tmdbID = await getPlatformID(username, 3);
       if (tmdbID != null && tmdbID.isNotEmpty) {
         ApiServices.tmdbUser = tmdbID;
       }

--- a/Mobile/media_tracker_mobile/lib/services/user_account_services.dart
+++ b/Mobile/media_tracker_mobile/lib/services/user_account_services.dart
@@ -1,0 +1,30 @@
+// This file will house all the write-to-database functions for the user (update account details/third party credentials)
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class UserAccountServices {
+  final supabase = Supabase.instance.client;
+
+  // Function to save/update third party credentials to the DB
+  Future<bool> savePlatformCredentials({
+    required String username,
+    required int platformId,
+    required String userPlatformId,
+  }) async {
+    try {
+      // Call the PostgreSQL RPC to commit/update the 3rd party service credentials
+      await supabase.rpc(
+        'add_3rd_party_id',
+        params: {
+          'username_input': username,
+          'platform_id_input': platformId,
+          'user_plat_id_input': userPlatformId,
+        },
+      );
+      print('Successful save or updating of data.');
+      return true;
+    } catch (e) {
+      print('Failed to link platform ID: $e');
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
- Successful linking of third party services in app. User enters the credentials and the app makes a stored procedure call to the DB to insert or update into the 'useraccounts' table to store the credentials.

- Credentials are also stored in the auth provider for session management

- Media data is successfully displayed to the user after linking the account.

- The 'Link Media Services' in the drawer menu now navigates to the linked services page to allow for editing/adding.