### PR TITLE
Mobile sean

### DIFF
--- a/Mobile/media_tracker_mobile/lib/config/api_connections.dart
+++ b/Mobile/media_tracker_mobile/lib/config/api_connections.dart
@@ -1,19 +1,19 @@
 class ApiServices {
   // STEAM CREDENTIALS
   static const String steamApiKey = '5553B2F6E49998D47EB298C086A05084';
-  static String steamUserId = '';
+  static String steamId = '';
 
   // LAST.FM CREDENTIALS
-  static String lastFmUser = '';
+  static String lastFmUsername = '';
   static const String lastFmApiKey = '1456c592b2d19dabd13468f0eee62dc9';
 
   // TMDB CREDENTIALS
-  static String tmdbUser = '';
+  static String tmdbSessionId = '';
   static const String tmdbAuthToken =
       'eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhOWNhY2ExNDI2MzI3YmQ5ZmE2MTI2NTRiNTk5NTIwNCIsIm5iZiI6MTczNzk5ODQ1OS40MDIsInN1YiI6IjY3OTdjMDdiMDljMjUyZTNhYjIzZGY2YyIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.zmcMBdlO7wllH_BvB1mZaqvydJC98yN7WuqhQePF004';
 
   static String get steamOwnedGamesUrl =>
-      'http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key=$steamApiKey&steamid=$steamUserId&include_appinfo=1&format=json';
+      'http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key=$steamApiKey&steamid=$steamId&include_appinfo=1&format=json';
 
   static String get lastFmBaseUrl => 'https://ws.audioscrobbler.com/2.0/';
 }

--- a/Mobile/media_tracker_mobile/lib/providers/auth_provider.dart
+++ b/Mobile/media_tracker_mobile/lib/providers/auth_provider.dart
@@ -98,21 +98,24 @@ class AuthNotifier extends StateNotifier<AuthState> {
     state = AuthState.empty();
 
     // Clear any global third-party API user ids
-    ApiServices.steamUserId = "";
-    ApiServices.lastFmUser = "";
-    ApiServices.tmdbUser = "";
+    ApiServices.steamId = "";
+    ApiServices.lastFmUsername = "";
+    ApiServices.tmdbSessionId = "";
   }
 
   // Update methods when a user links third party API service
   void updateSteamId(String? id) {
+    ApiServices.steamId = id ?? "";
     state = state.copyWith(steamId: id, clearSteamId: id == null);
   }
 
   void updateTmdbSessionId(String? id) {
+    ApiServices.tmdbSessionId = id ?? "";
     state = state.copyWith(tmdbSessionId: id, clearTmdbSessionId: id == null);
   }
 
   void updateLastFmUsername(String? username) {
+    ApiServices.lastFmUsername = username ?? "";
     state = state.copyWith(
       lastFmUsername: username,
       clearLastFmUsername: username == null,

--- a/Mobile/media_tracker_mobile/lib/screens/account_linking_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/account_linking_screen.dart
@@ -23,11 +23,13 @@ class AccountLinkingScreen extends ConsumerWidget {
               platformName: 'Steam',
               linkedValue: auth.steamId,
               onLink: (id) async {
+                final vanityUrl = await UserAccountServices()
+                    .fetchSteamIDFromVanity(id);
                 final success = await UserAccountServices()
                     .savePlatformCredentials(
                       username: auth.username!,
                       platformId: 1,
-                      userPlatformId: id,
+                      userPlatformId: vanityUrl,
                     );
 
                 if (success) {
@@ -50,7 +52,24 @@ class AccountLinkingScreen extends ConsumerWidget {
                   );
                 }
               },
-              onUnlink: () => notifier.updateSteamId(null),
+              onUnlink: () async {
+                final success = await UserAccountServices()
+                    .removePlatformCredentials(
+                      username: auth.username!,
+                      platformId: 1,
+                      userPlatformId: auth.steamId!,
+                    );
+
+                if (success) {
+                  notifier.updateSteamId(null);
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Failed to unlink Steam account.'),
+                    ),
+                  );
+                }
+              },
               onEdit: () {},
             ),
             LinkAccountCard(
@@ -84,7 +103,24 @@ class AccountLinkingScreen extends ConsumerWidget {
                   );
                 }
               },
-              onUnlink: () => notifier.updateLastFmUsername(null),
+              onUnlink: () async {
+                final success = await UserAccountServices()
+                    .removePlatformCredentials(
+                      username: auth.username!,
+                      platformId: 2,
+                      userPlatformId: auth.lastFmUsername!,
+                    );
+
+                if (success) {
+                  notifier.updateLastFmUsername(null);
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Failed to unlink Last.FM account.'),
+                    ),
+                  );
+                }
+              },
               onEdit: () {},
             ),
             LinkAccountCard(
@@ -118,7 +154,24 @@ class AccountLinkingScreen extends ConsumerWidget {
                   );
                 }
               },
-              onUnlink: () => notifier.updateTmdbSessionId(null),
+              onUnlink: () async {
+                final success = await UserAccountServices()
+                    .removePlatformCredentials(
+                      username: auth.username!,
+                      platformId: 3,
+                      userPlatformId: auth.tmdbSessionId!,
+                    );
+
+                if (success) {
+                  notifier.updateTmdbSessionId(null);
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Failed to unlink TMDB account.'),
+                    ),
+                  );
+                }
+              },
               onEdit: () {},
             ),
           ],

--- a/Mobile/media_tracker_mobile/lib/screens/media_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/media_screen.dart
@@ -55,12 +55,13 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
         if (auth.steamId != null && _steamGames.isEmpty) _loadSteamGames();
         break;
       case 1:
-        if (auth.tmdbSessionId != null && _tmdbAccount == null) _loadTmdbData();
+        if (auth.lastFmUsername != null &&
+            (_topArtists.isEmpty || _recentTracks.isEmpty)) {
+          _loadLastFmData();
+        }
         break;
       case 2:
-        if (auth.lastFmUsername != null &&
-            (_topArtists.isEmpty || _recentTracks.isEmpty))
-          _loadLastFmData();
+        if (auth.tmdbSessionId != null && _tmdbAccount == null) _loadTmdbData();
         break;
     }
   }
@@ -168,11 +169,11 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
             icon: Icon(Icons.videogame_asset),
             label: 'Steam',
           ),
-          BottomNavigationBarItem(icon: Icon(Icons.movie), label: 'TMDB'),
           BottomNavigationBarItem(
             icon: Icon(Icons.music_note),
             label: 'Last.fm',
           ),
+          BottomNavigationBarItem(icon: Icon(Icons.movie), label: 'TMDB'),
         ],
       ),
     );
@@ -187,13 +188,13 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
         if (auth.steamId == null) return _noMediaLinkedPrompt("Steam");
         return _buildSteamList();
       case 1:
-        if (_isLoadingTmdb) return _loading();
-        if (auth.tmdbSessionId == null) return _noMediaLinkedPrompt("TMDB");
-        return _buildTmdbSection();
-      case 2:
         if (_isLoadingLastFm) return _loading();
         if (auth.lastFmUsername == null) return _noMediaLinkedPrompt("Last.fm");
         return _buildLastFmSection();
+      case 2:
+        if (_isLoadingTmdb) return _loading();
+        if (auth.tmdbSessionId == null) return _noMediaLinkedPrompt("TMDB");
+        return _buildTmdbSection();
       default:
         return Center(child: Text("Coming soon..."));
     }

--- a/Mobile/media_tracker_mobile/lib/services/auth_service.dart
+++ b/Mobile/media_tracker_mobile/lib/services/auth_service.dart
@@ -55,17 +55,17 @@ class AuthService {
 
       // Fetch linked platform IDs (Steam, Last.fm, TMDB) from the useraccounts table
       // If the Steam ID, last.fm ID, or TMDB ID exists, assign them globally via ApiServices
-      final steamID = await getPlatformID(username, 1);
-      if (steamID != null && steamID.isNotEmpty) {
-        ApiServices.steamUserId = steamID;
+      final steamId = await getPlatformID(username, 1);
+      if (steamId != null && steamId.isNotEmpty) {
+        ApiServices.steamId = steamId;
       }
       final lastfmID = await getPlatformID(username, 2);
       if (lastfmID != null && lastfmID.isNotEmpty) {
-        ApiServices.lastFmUser = lastfmID;
+        ApiServices.lastFmUsername = lastfmID;
       }
       final tmdbID = await getPlatformID(username, 3);
       if (tmdbID != null && tmdbID.isNotEmpty) {
-        ApiServices.tmdbUser = tmdbID;
+        ApiServices.tmdbSessionId = tmdbID;
       }
 
       // If user profile data was found, update the global auth state using authProvider
@@ -78,7 +78,7 @@ class AuthService {
               lastName: userInfo[0]['last_name'] ?? '',
               email: userInfo[0]['email'] ?? '',
               token: result,
-              steamID: steamID,
+              steamID: steamId,
               lastFmUsername: lastfmID,
               tmdbSessionId: tmdbID
             );

--- a/Mobile/media_tracker_mobile/lib/services/media_api/lastfm_service.dart
+++ b/Mobile/media_tracker_mobile/lib/services/media_api/lastfm_service.dart
@@ -8,7 +8,7 @@ import '/config/api_connections.dart';
 Future<LastFmUser> fetchLastFmUser() async {
   final url =
       '${ApiServices.lastFmBaseUrl}?method=user.getinfo'
-      '&user=${ApiServices.lastFmUser}'
+      '&user=${ApiServices.lastFmUsername}'
       '&api_key=${ApiServices.lastFmApiKey}'
       '&format=json';
 
@@ -24,7 +24,7 @@ Future<LastFmUser> fetchLastFmUser() async {
 Future<List<LastFmArtist>> fetchLastFmTopArtists() async {
   final url =
       '${ApiServices.lastFmBaseUrl}?method=user.gettopartists'
-      '&user=${ApiServices.lastFmUser}'
+      '&user=${ApiServices.lastFmUsername}'
       '&api_key=${ApiServices.lastFmApiKey}'
       '&limit=5'
       '&format=json';
@@ -42,7 +42,7 @@ Future<List<LastFmArtist>> fetchLastFmTopArtists() async {
 Future<List<LastFmTrack>> fetchLastFmRecentTracks() async {
   final url =
       '${ApiServices.lastFmBaseUrl}?method=user.getrecenttracks'
-      '&user=${ApiServices.lastFmUser}'
+      '&user=${ApiServices.lastFmUsername}'
       '&api_key=${ApiServices.lastFmApiKey}'
       '&limit=5'
       '&format=json';

--- a/Mobile/media_tracker_mobile/lib/services/media_api/steam_service.dart
+++ b/Mobile/media_tracker_mobile/lib/services/media_api/steam_service.dart
@@ -8,8 +8,16 @@ Future<List<SteamGame>> fetchSteamGames() async {
 
   if (response.statusCode == 200) {
     final data = json.decode(response.body);
-    final games = data['response']['games'] as List<dynamic>;
-    return games.map((game) => SteamGame.fromJson(game)).toList();
+    final gameList = data['response']['games'];
+
+    if (gameList == null) {
+      print('No games returned - check Steam ID.');
+      return [];
+    }
+
+    return (gameList as List<dynamic>)
+        .map((game) => SteamGame.fromJson(game))
+        .toList();
   } else {
     throw Exception('Failed to load Steam games');
   }

--- a/Mobile/media_tracker_mobile/lib/services/media_api/tmdb_service.dart
+++ b/Mobile/media_tracker_mobile/lib/services/media_api/tmdb_service.dart
@@ -13,7 +13,7 @@ class TMDBService {
 
   static Future<TMDBAccount> fetchAccountDetails() async {
     final url = Uri.parse(
-      'https://api.themoviedb.org/3/account/${ApiServices.tmdbUser}',
+      'https://api.themoviedb.org/3/account/${ApiServices.tmdbSessionId}',
     );
 
     final response = await http.get(
@@ -30,7 +30,7 @@ class TMDBService {
 
   static Future<List<TMDBMovie>> fetchRatedMovies() async {
     final url = Uri.parse(
-      'https://api.themoviedb.org/3/account/${ApiServices.tmdbUser}/rated/movies?language=en-US&page=1&sort_by=created_at.desc',
+      'https://api.themoviedb.org/3/account/${ApiServices.tmdbSessionId}/rated/movies?language=en-US&page=1&sort_by=created_at.desc',
     );
 
     final response = await http.get(
@@ -48,7 +48,7 @@ class TMDBService {
 
   static Future<List<TMDBTvShow>> fetchFavoriteTvShows() async {
     final url = Uri.parse(
-      'https://api.themoviedb.org/3/account/${ApiServices.tmdbUser}/favorite/tv?language=en-US&page=1&sort_by=created_at.asc',
+      'https://api.themoviedb.org/3/account/${ApiServices.tmdbSessionId}/favorite/tv?language=en-US&page=1&sort_by=created_at.asc',
     );
 
     final response = await http.get(

--- a/Mobile/media_tracker_mobile/lib/services/user_account_services.dart
+++ b/Mobile/media_tracker_mobile/lib/services/user_account_services.dart
@@ -43,7 +43,7 @@ class UserAccountServices {
         params: {
           'username_input': username,
           'platform_id_input': platformId,
-          'user_platform_id_input': userPlatformId,
+          'user_plat_id_input': userPlatformId,
         },
       );
       print('Successfully removed 3rd party credentials');

--- a/Mobile/media_tracker_mobile/lib/services/user_account_services.dart
+++ b/Mobile/media_tracker_mobile/lib/services/user_account_services.dart
@@ -1,4 +1,7 @@
 // This file will house all the write-to-database functions for the user (update account details/third party credentials)
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:media_tracker_test/config/api_connections.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class UserAccountServices {
@@ -26,5 +29,53 @@ class UserAccountServices {
       print('Failed to link platform ID: $e');
       return false;
     }
+  }
+
+  Future<bool> removePlatformCredentials({
+    required String username,
+    required int platformId,
+    required String userPlatformId,
+  }) async {
+    try {
+      // Call the PostgreSQL RPC to remove 3rd party service credentials
+      await supabase.rpc(
+        'delete_3rd_party',
+        params: {
+          'username_input': username,
+          'platform_id_input': platformId,
+          'user_platform_id_input': userPlatformId,
+        },
+      );
+      print('Successfully removed 3rd party credentials');
+      return true;
+    } catch (e) {
+      print('Failed to remove 3rd party credentials: $e');
+      return false;
+    }
+  }
+
+  // Function to fetch Steam ID from a Vanity username
+  Future<String> fetchSteamIDFromVanity(String username) async {
+    try {
+      final response = await http.get(
+        Uri.parse(
+          'http://api.steampowered.com/ISteamUser/ResolveVanityURL/v0001/?key=${ApiServices.steamApiKey}&vanityurl=$username',
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        if (data['response']['success'] == 1) {
+          return data['response']['steamid'];
+        } else {
+          print('Vanity URL not found: ${data['response']['message']}');
+        }
+      } else {
+        print('Failed to fetch Steam ID: HTTP ${response.statusCode}');
+      }
+    } catch (e) {
+      print('Failed to resolve Steam ID from Vanity username: $e');
+    }
+    return '';
   }
 }


### PR DESCRIPTION
PR Created by Sean

- Users can now link and unlink the respective 3rd party credentials when logged in to their account through the use of the stored procedures created 'add_3rd_party_id' and 'delete_3rd_party'

- Altered some variable names in the api_connections file (steamId, lastFmUsername, and tmdbSessionId) to be consistent across the entire app. This allows for the auth state to update automatically when linking/unlinking a service. Adjusted variable names throughout the media_api functions to match.

- Re-ordered the bottom navigation bar to show TMDB last

- Update the RPC call to the correct naming structure for 'user_plat_id_input'