### PR TITLE
Mobile sean

### DIFF
--- a/Mobile/media_tracker_mobile/lib/config/api_connections.dart
+++ b/Mobile/media_tracker_mobile/lib/config/api_connections.dart
@@ -2,18 +2,16 @@ class ApiServices {
   // STEAM CREDENTIALS
   static const String steamApiKey = '5553B2F6E49998D47EB298C086A05084';
   static String steamId = '';
+  static String get steamOwnedGamesUrl =>
+      'http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key=$steamApiKey&steamid=$steamId&include_appinfo=1&format=json';
 
   // LAST.FM CREDENTIALS
   static String lastFmUsername = '';
   static const String lastFmApiKey = '1456c592b2d19dabd13468f0eee62dc9';
+  static String get lastFmBaseUrl => 'https://ws.audioscrobbler.com/2.0/';
 
   // TMDB CREDENTIALS
+  static const String tmdbApiKey = 'c42aedff935d3382bc95b0f7e8f5f7e3';
   static String tmdbSessionId = '';
-  static const String tmdbAuthToken =
-      'eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJhOWNhY2ExNDI2MzI3YmQ5ZmE2MTI2NTRiNTk5NTIwNCIsIm5iZiI6MTczNzk5ODQ1OS40MDIsInN1YiI6IjY3OTdjMDdiMDljMjUyZTNhYjIzZGY2YyIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.zmcMBdlO7wllH_BvB1mZaqvydJC98yN7WuqhQePF004';
-
-  static String get steamOwnedGamesUrl =>
-      'http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key=$steamApiKey&steamid=$steamId&include_appinfo=1&format=json';
-
-  static String get lastFmBaseUrl => 'https://ws.audioscrobbler.com/2.0/';
+  static String tmdbAccountId = '';
 }

--- a/Mobile/media_tracker_mobile/lib/providers/auth_provider.dart
+++ b/Mobile/media_tracker_mobile/lib/providers/auth_provider.dart
@@ -80,6 +80,11 @@ class AuthNotifier extends StateNotifier<AuthState> {
     String? tmdbSessionId,
     String? lastFmUsername,
   }) {
+    // Sync third-party global API variables
+    ApiServices.steamId = steamID ?? "";
+    ApiServices.tmdbSessionId = tmdbSessionId ?? "";
+    ApiServices.lastFmUsername = lastFmUsername ?? "";
+    
     state = AuthState(
       username: username,
       firstName: firstName,

--- a/Mobile/media_tracker_mobile/lib/screens/account_linking_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/account_linking_screen.dart
@@ -43,6 +43,7 @@ class AccountLinkingScreen extends ConsumerWidget {
                   // Update state only after confirming the value from DB
                   if (updatedSteamId != null) {
                     notifier.updateSteamId(updatedSteamId);
+                    Navigator.pop(context, true);
                   }
                 } else {
                   ScaffoldMessenger.of(context).showSnackBar(
@@ -94,6 +95,7 @@ class AccountLinkingScreen extends ConsumerWidget {
                   // Update state only after confirming the value from DB
                   if (updatedLastfmUsername != null) {
                     notifier.updateLastFmUsername(updatedLastfmUsername);
+                    Navigator.pop(context, true);
                   }
                 } else {
                   ScaffoldMessenger.of(context).showSnackBar(
@@ -145,6 +147,7 @@ class AccountLinkingScreen extends ConsumerWidget {
                   // Update state only after confirming the value from DB
                   if (updatedTmdbSessionId != null) {
                     notifier.updateTmdbSessionId(updatedTmdbSessionId);
+                    Navigator.pop(context, true);
                   }
                 } else {
                   ScaffoldMessenger.of(context).showSnackBar(

--- a/Mobile/media_tracker_mobile/lib/screens/home_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/home_screen.dart
@@ -57,9 +57,9 @@ class _HomeScreenState extends State<HomeScreen> {
             children: [
               Text(
                 'Not Signed In',
-                style: Theme.of(context).textTheme.headlineLarge
-              )
-            ]
+                style: Theme.of(context).textTheme.headlineLarge,
+              ),
+            ],
           ),
           SizedBox(height: 16),
           Row(

--- a/Mobile/media_tracker_mobile/lib/screens/media_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/media_screen.dart
@@ -219,8 +219,11 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
             ElevatedButton.icon(
               icon: Icon(Icons.link),
               label: Text("Link $platform Account"),
-              onPressed: () {
-                Navigator.pushNamed(context, '/linkAccounts');
+              onPressed: () async {
+                final didLink = await Navigator.pushNamed(context, '/linkAccounts');
+                if (didLink == true) {
+                  _loadPlatformData(_selectedIndex);
+                }
               },
             ),
           ],

--- a/Mobile/media_tracker_mobile/lib/services/media_api/tmdb_service.dart
+++ b/Mobile/media_tracker_mobile/lib/services/media_api/tmdb_service.dart
@@ -4,39 +4,104 @@ import '../../models/tmdb/tmdb_account.dart';
 import '../../models/tmdb/tmdb_movie.dart';
 import '../../models/tmdb/tmdb_tv_show.dart';
 import '/config/api_connections.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class TMDBService {
-  static Map<String, String> _headers(String authToken) => {
-    'Authorization': 'Bearer $authToken',
-    'accept': 'application/json',
-  };
 
+  // Requests a temporary request token from TMDB, used for user authentication
+  static Future<String?> getRequestToken() async {
+    final url = Uri.parse(
+      'https://api.themoviedb.org/3/authentication/token/new?api_key=${ApiServices.tmdbApiKey}',
+    );
+    final response = await http.get(url);
+
+    // If successful, return the request token string
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body)['request_token'];
+    } else {
+      return null; // Token request failed
+    }
+  }
+
+  // Opens the TMDB authentication URL in the external browser to let user approve access
+  static Future<void> launchAuthUrl(String requestToken) async {
+    final url = Uri.parse(
+      'https://www.themoviedb.org/authenticate/$requestToken',
+    );
+
+    // Launch the URL in external browser — fails if no browser is available
+    if (!await launchUrl(url, mode: LaunchMode.externalApplication)) {
+      throw 'Could not launch $url';
+    }
+  }
+
+  // Exchanges the approved request token for a permanent session ID
+  static Future<String?> createSession(String requestToken) async {
+    final url = Uri.parse(
+      'https://api.themoviedb.org/3/authentication/session/new?api_key=${ApiServices.tmdbApiKey}',
+    );
+
+    // Store and return session ID if successful
+    final response = await http.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'request_token': requestToken}),
+    );
+
+    if (response.statusCode == 200) {
+      final sessionId = jsonDecode(response.body)['session_id'];
+      ApiServices.tmdbSessionId = sessionId; // store it globally
+      return sessionId;
+    }
+    return null; // Session creation failed
+  }
+
+  // Fetches the TMDB numeric account ID using the session ID
+  static Future<int?> fetchAccountId(String sessionId) async {
+    final url = Uri.parse(
+      'https://api.themoviedb.org/3/account?api_key=${ApiServices.tmdbApiKey}&session_id=$sessionId',
+    );
+
+    final response = await http.get(url);
+
+    // Extract and store the account ID
+    if (response.statusCode == 200) {
+      final id = jsonDecode(response.body)['id'];
+      ApiServices.tmdbAccountId = id;
+      return id;
+    }
+    return null; // Failed to fetch account ID
+  }
+
+  // Fetches full account details (e.g., username, name, ID) for the currently authenticated user
   static Future<TMDBAccount> fetchAccountDetails() async {
     final url = Uri.parse(
-      'https://api.themoviedb.org/3/account/${ApiServices.tmdbSessionId}',
+      'https://api.themoviedb.org/3/account?api_key=${ApiServices.tmdbApiKey}&session_id=${ApiServices.tmdbSessionId}',
     );
 
-    final response = await http.get(
-      url,
-      headers: _headers(ApiServices.tmdbAuthToken),
-    );
+    final response = await http.get(url);
+
+    // Parse and return as a TMDBAccount model
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body);
+      ApiServices.tmdbAccountId = data['id'].toString(); // Cache the ID
       return TMDBAccount.fromJson(data);
     } else {
       throw Exception('Failed to fetch TMDB account details');
     }
   }
 
+  // Fetches a list of movies the user has rated, sorted by most recently rated
   static Future<List<TMDBMovie>> fetchRatedMovies() async {
     final url = Uri.parse(
-      'https://api.themoviedb.org/3/account/${ApiServices.tmdbSessionId}/rated/movies?language=en-US&page=1&sort_by=created_at.desc',
+      'https://api.themoviedb.org/3/account/${ApiServices.tmdbAccountId}/rated/movies'
+      '?api_key=${ApiServices.tmdbApiKey}&session_id=${ApiServices.tmdbSessionId}'
+      '&language=en-US&page=1&sort_by=created_at.desc',
     );
 
-    final response = await http.get(
-      url,
-      headers: _headers(ApiServices.tmdbAuthToken),
-    );
+    final response = await http.get(url);
+
+    // Parse and return as a list of TMDBMovie objects
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body);
       final results = data['results'] as List<dynamic>;
@@ -46,15 +111,17 @@ class TMDBService {
     }
   }
 
+  // Fetches the user's favorite TV shows, sorted by the order they were favorited
   static Future<List<TMDBTvShow>> fetchFavoriteTvShows() async {
     final url = Uri.parse(
-      'https://api.themoviedb.org/3/account/${ApiServices.tmdbSessionId}/favorite/tv?language=en-US&page=1&sort_by=created_at.asc',
+      'https://api.themoviedb.org/3/account/${ApiServices.tmdbAccountId}/favorite/tv'
+      '?api_key=${ApiServices.tmdbApiKey}&session_id=${ApiServices.tmdbSessionId}'
+      '&language=en-US&page=1&sort_by=created_at.asc',
     );
 
-    final response = await http.get(
-      url,
-      headers: _headers(ApiServices.tmdbAuthToken),
-    );
+    final response = await http.get(url);
+
+    // Parse and return as a list of TMDBTvShow objects
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body);
       final results = data['results'] as List<dynamic>;

--- a/Mobile/media_tracker_mobile/pubspec.lock
+++ b/Mobile/media_tracker_mobile/pubspec.lock
@@ -534,7 +534,7 @@ packages:
     source: hosted
     version: "1.4.0"
   url_launcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher
       sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"

--- a/Mobile/media_tracker_mobile/pubspec.yaml
+++ b/Mobile/media_tracker_mobile/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
 
   #This is for the bycryp package
   bcrypt: ^1.1.3
+  url_launcher: ^6.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
PR created by Sean

- Resolved an issue with the third party services not updating the media_screen after a successful linking directly after a log-in without that service linked. Now the ApiService updates the login() function in the AuthNotifier to reflect the currently linked services

- User's can now enter there TMDB username into the account_linking_screen, which will launch the defaul browser for the user to approve/deny linking. Once the user approves, they can navigate back to the flutter app and press continue on the alert dialog, which will link their account.

- Added the getRequestToken(), launchAuthUrl(), createSession(), and fetchAccountId() function in the tmdb_service file to centralize all logic surrounding fetching the user's TMDB information.

- Removed authToken and now use a TMDB API key (information regarding obtaining key is in the resources channel of the discord).

- Added the url_launcher package to the pubspec.yaml file to allow for links to launch in an external browser