### PR TITLE
Mobile sean

### DIFF
--- a/Mobile/media_tracker_mobile/lib/main.dart
+++ b/Mobile/media_tracker_mobile/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:media_tracker_test/screens/account_linking_screen.dart';
 import 'package:media_tracker_test/screens/auth/login_screen.dart';
 import 'package:media_tracker_test/screens/auth/register_screen.dart';
-import 'package:media_tracker_test/screens/media_screen.dart';
+import 'package:media_tracker_test/screens/media/media_screen.dart';
 import 'screens/home_screen.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'models/theme.dart' as theme;

--- a/Mobile/media_tracker_mobile/lib/models/steam/steam_model.dart
+++ b/Mobile/media_tracker_mobile/lib/models/steam/steam_model.dart
@@ -40,4 +40,6 @@ class SteamGame {
       playtimeDisconnected: json['playtime_disconnected'] ?? 0,
     );
   }
+
+  bool get isFavorite => false;
 }

--- a/Mobile/media_tracker_mobile/lib/screens/account_linking_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/account_linking_screen.dart
@@ -22,15 +22,19 @@ class AccountLinkingScreen extends ConsumerWidget {
           children: [
             LinkAccountCard(
               platformName: 'Steam',
+              inputLabel: 'Enter Vanity URL or Steam ID',
               linkedValue: auth.steamId,
-              onLink: (id) async {
-                final vanityUrl = await UserAccountServices()
-                    .fetchSteamIDFromVanity(id);
+              onLink: (input) async {
+                // Try to resolve Vanity URL to Steam ID
+                final steamId = await UserAccountServices()
+                    .fetchSteamIDFromVanity(input);
+
+                // Save the resolved Steam ID
                 final success = await UserAccountServices()
                     .savePlatformCredentials(
                       username: auth.username!,
                       platformId: 1,
-                      userPlatformId: vanityUrl,
+                      userPlatformId: steamId,
                     );
 
                 if (success) {
@@ -180,6 +184,7 @@ class AccountLinkingScreen extends ConsumerWidget {
             // ),
             LinkAccountCard(
               platformName: 'TMDB',
+              inputLabel: 'Enter TMDB Username',
               linkedValue: auth.tmdbSessionId,
               onLink: (_) async {
                 final requestToken = await TMDBService.getRequestToken();

--- a/Mobile/media_tracker_mobile/lib/screens/auth/login_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/auth/login_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:media_tracker_test/screens/media_screen.dart';
+import 'package:media_tracker_test/screens/media/media_screen.dart';
 import '../../services/auth_service.dart';
 
 class LoginScreen extends ConsumerStatefulWidget {

--- a/Mobile/media_tracker_mobile/lib/screens/auth/register_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/auth/register_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:media_tracker_test/screens/media_screen.dart';
+import 'package:media_tracker_test/screens/media/media_screen.dart';
 import '../../services/auth_service.dart';
 
 class RegisterScreen extends ConsumerStatefulWidget {

--- a/Mobile/media_tracker_mobile/lib/screens/media/lastfm_section.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/media/lastfm_section.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import '../../models/lastfm/lastfm_artist.dart';
+import '../../models/lastfm/lastfm_track.dart';
+import '../../models/lastfm/lastfm_user.dart';
+
+Widget buildLastFmSection(
+  LastFmUser? user,
+  List<LastFmArtist> topArtists,
+  List<LastFmTrack> recentTracks,
+) {
+  return ListView(
+    padding: const EdgeInsets.all(12),
+    children: [
+      if (user != null) ...[
+        Text(
+          "User: ${user.name}",
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        Text("Plays: ${user.playCount}"),
+        const SizedBox(height: 12),
+      ],
+      const Text(
+        "Top Artists",
+        style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+      ),
+      ...topArtists.map(
+        (artist) => ListTile(
+          title: Text(artist.name),
+          subtitle: Text("Plays: ${artist.playCount}"),
+        ),
+      ),
+      const SizedBox(height: 12),
+      const Text(
+        "Recent Tracks",
+        style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+      ),
+      ...recentTracks.map(
+        (track) => ListTile(
+          title: Text(track.name),
+          subtitle: Text("By: ${track.artist}"),
+          trailing: Text(track.formattedDate ?? "Now Playing"),
+        ),
+      ),
+    ],
+  );
+}

--- a/Mobile/media_tracker_mobile/lib/screens/media/media_details_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/media/media_details_screen.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import '../../services/media_api/steam_service.dart';
+
+class MediaDetailsScreen extends StatefulWidget {
+  final String appId; // required to fetch from Steam API
+  final String title;
+  final String subtitle;
+
+  const MediaDetailsScreen({
+    super.key,
+    required this.appId,
+    required this.title,
+    required this.subtitle,
+  });
+
+  @override
+  State<MediaDetailsScreen> createState() => _MediaDetailsScreenState();
+}
+
+class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
+  String? _imageUrl;
+  List<String> _extraDetails = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSteamGameDetails();
+  }
+
+  Future<void> _loadSteamGameDetails() async {
+    final details = await fetchSteamAppDetails(widget.appId);
+    if (details != null) {
+      setState(() {
+        _extraDetails = [
+          'Genres: ${_formatGenres(details['genres'])}',
+          'Developer: ${details['developers']?.join(', ')}',
+          'Release Date: ${details['release_date']['date']}',
+          'Description: ${details['short_description']}',
+        ];
+        _imageUrl = details['header_image'];
+      });
+    }
+  }
+
+  String _formatGenres(List<dynamic>? genres) {
+    return genres?.map((g) => g['description']).join(', ') ?? 'Unknown';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.title)),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (_imageUrl != null)
+              Center(
+                child: Image.network(
+                  _imageUrl!,
+                  fit: BoxFit.cover,
+                  height: 200,
+                ),
+              ),
+            const SizedBox(height: 16),
+            Text(widget.subtitle, style: const TextStyle(fontSize: 16)),
+            const SizedBox(height: 12),
+            ..._extraDetails.map(
+              (detail) => Padding(
+                padding: const EdgeInsets.only(bottom: 8.0),
+                child: Text(
+                  detail,
+                  style: const TextStyle(fontSize: 14, color: Colors.grey),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/Mobile/media_tracker_mobile/lib/screens/media/media_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/media/media_screen.dart
@@ -2,18 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:media_tracker_test/providers/auth_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../models/lastfm/lastfm_artist.dart';
-import '../models/lastfm/lastfm_track.dart';
-import '../models/lastfm/lastfm_user.dart';
-import '../models/steam/steam_model.dart';
-import '../models/tmdb/tmdb_account.dart';
-import '../models/tmdb/tmdb_movie.dart';
-import '../models/tmdb/tmdb_tv_show.dart';
-import '../services/media_api/steam_service.dart';
-import '../services/media_api/lastfm_service.dart';
-import '../services/media_api/tmdb_service.dart';
-import 'home_screen.dart';
-import 'widgets/drawer_menu.dart';
+import '../../models/lastfm/lastfm_artist.dart';
+import '../../models/lastfm/lastfm_track.dart';
+import '../../models/lastfm/lastfm_user.dart';
+import '../../models/steam/steam_model.dart';
+import '../../models/tmdb/tmdb_account.dart';
+import '../../models/tmdb/tmdb_movie.dart';
+import '../../models/tmdb/tmdb_tv_show.dart';
+import '../../services/media_api/steam_service.dart';
+import '../../services/media_api/lastfm_service.dart';
+import '../../services/media_api/tmdb_service.dart';
+import 'steam_section.dart';
+import 'lastfm_section.dart';
+import 'tmdb_section.dart';
+import '../home_screen.dart';
+import '../widgets/drawer_menu.dart';
 
 class MediaScreen extends ConsumerStatefulWidget {
   const MediaScreen({super.key});
@@ -186,15 +189,15 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
       case 0:
         if (_isLoadingSteam) return _loading();
         if (auth.steamId == null) return _noMediaLinkedPrompt("Steam");
-        return _buildSteamList();
+        return buildSteamSection(_steamGames);
       case 1:
         if (_isLoadingLastFm) return _loading();
         if (auth.lastFmUsername == null) return _noMediaLinkedPrompt("Last.fm");
-        return _buildLastFmSection();
+        return buildLastFmSection(_lastFmUser, _topArtists, _recentTracks);
       case 2:
         if (_isLoadingTmdb) return _loading();
         if (auth.tmdbSessionId == null) return _noMediaLinkedPrompt("TMDB");
-        return _buildTmdbSection();
+        return buildTmdbSection(_tmdbAccount, _ratedMovies, _favoriteTvShows);
       default:
         return Center(child: Text("Coming soon..."));
     }
@@ -220,7 +223,10 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
               icon: Icon(Icons.link),
               label: Text("Link $platform Account"),
               onPressed: () async {
-                final didLink = await Navigator.pushNamed(context, '/linkAccounts');
+                final didLink = await Navigator.pushNamed(
+                  context,
+                  '/linkAccounts',
+                );
                 if (didLink == true) {
                   _loadPlatformData(_selectedIndex);
                 }
@@ -229,91 +235,6 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
           ],
         ),
       ),
-    );
-  }
-
-  Widget _buildSteamList() {
-    return ListView.builder(
-      itemCount: _steamGames.length,
-      itemBuilder: (context, index) {
-        final game = _steamGames[index];
-        return ListTile(
-          title: Text(game.name),
-          subtitle: Text('Played: ${game.playtimeForever} mins'),
-        );
-      },
-    );
-  }
-
-  Widget _buildLastFmSection() {
-    return ListView(
-      padding: const EdgeInsets.all(12),
-      children: [
-        if (_lastFmUser != null) ...[
-          Text(
-            "User: ${_lastFmUser!.name}",
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-          ),
-          Text("Plays: ${_lastFmUser!.playCount}"),
-          const SizedBox(height: 12),
-        ],
-        Text(
-          "Top Artists",
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-        ),
-        ..._topArtists.map(
-          (artist) => ListTile(
-            title: Text(artist.name),
-            subtitle: Text("Plays: ${artist.playCount}"),
-          ),
-        ),
-        const SizedBox(height: 12),
-        Text(
-          "Recent Tracks",
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-        ),
-        ..._recentTracks.map(
-          (track) => ListTile(
-            title: Text(track.name),
-            subtitle: Text("By: ${track.artist}"),
-            trailing: Text(track.formattedDate ?? "Now Playing"),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildTmdbSection() {
-    return ListView(
-      padding: const EdgeInsets.all(12),
-      children: [
-        if (_tmdbAccount != null) ...[
-          Text(
-            "User: ${_tmdbAccount!.username}",
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 12),
-        ],
-        Text(
-          "Rated Movies",
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-        ),
-        ..._ratedMovies.map(
-          (movie) => ListTile(
-            title: Text(movie.title),
-            subtitle: Text(movie.overview),
-          ),
-        ),
-        const SizedBox(height: 12),
-        Text(
-          "Favorite TV Shows",
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-        ),
-        ..._favoriteTvShows.map(
-          (show) =>
-              ListTile(title: Text(show.name), subtitle: Text(show.overview)),
-        ),
-      ],
     );
   }
 }

--- a/Mobile/media_tracker_mobile/lib/screens/media/steam_section.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/media/steam_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:media_tracker_test/screens/media/media_details_screen.dart';
 import '../../models/steam/steam_model.dart';
 
 Widget buildSteamSection(List<SteamGame> steamGames) {
@@ -9,6 +10,29 @@ Widget buildSteamSection(List<SteamGame> steamGames) {
       return ListTile(
         title: Text(game.name),
         subtitle: Text('Played: ${game.playtimeForever} mins'),
+        trailing: IconButton(
+          icon: Icon(
+            game.isFavorite ? Icons.star : Icons.star_border,
+            color: game.isFavorite ? Colors.yellow : Colors.grey,
+          ),
+          onPressed: () {
+            // toggle favorite logic
+          },
+        ),
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder:
+                  (_) => MediaDetailsScreen(
+                    appId: game.appId.toString(),
+                    title: game.name,
+                    subtitle:
+                        'Total playtime: ${game.playtimeForever} minutes',
+                  ),
+            ),
+          );
+        },
       );
     },
   );

--- a/Mobile/media_tracker_mobile/lib/screens/media/steam_section.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/media/steam_section.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import '../../models/steam/steam_model.dart';
+
+Widget buildSteamSection(List<SteamGame> steamGames) {
+  return ListView.builder(
+    itemCount: steamGames.length,
+    itemBuilder: (context, index) {
+      final game = steamGames[index];
+      return ListTile(
+        title: Text(game.name),
+        subtitle: Text('Played: ${game.playtimeForever} mins'),
+      );
+    },
+  );
+}

--- a/Mobile/media_tracker_mobile/lib/screens/media/tmdb_section.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/media/tmdb_section.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import '../../models/tmdb/tmdb_account.dart';
+import '../../models/tmdb/tmdb_movie.dart';
+import '../../models/tmdb/tmdb_tv_show.dart';
+
+Widget buildTmdbSection(
+  TMDBAccount? account,
+  List<TMDBMovie> ratedMovies,
+  List<TMDBTvShow> favoriteTvShows,
+) {
+  return ListView(
+    padding: const EdgeInsets.all(12),
+    children: [
+      if (account != null) ...[
+        Text(
+          "User: ${account.username}",
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 12),
+      ],
+      const Text(
+        "Rated Movies",
+        style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+      ),
+      ...ratedMovies.map(
+        (movie) =>
+            ListTile(title: Text(movie.title), subtitle: Text(movie.overview)),
+      ),
+      const SizedBox(height: 12),
+      const Text(
+        "Favorite TV Shows",
+        style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+      ),
+      ...favoriteTvShows.map(
+        (show) =>
+            ListTile(title: Text(show.name), subtitle: Text(show.overview)),
+      ),
+    ],
+  );
+}

--- a/Mobile/media_tracker_mobile/lib/screens/widgets/link_account_card.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/widgets/link_account_card.dart
@@ -8,6 +8,7 @@ class LinkAccountCard extends ConsumerStatefulWidget {
   final void Function(String) onLink;
   final VoidCallback onUnlink;
   final VoidCallback onEdit;
+  final String? inputLabel;
 
   const LinkAccountCard({
     super.key,
@@ -16,6 +17,7 @@ class LinkAccountCard extends ConsumerStatefulWidget {
     required this.onLink,
     required this.onUnlink,
     required this.onEdit,
+    this.inputLabel,
   });
 
   @override
@@ -96,7 +98,7 @@ class _LinkAccountCardState extends ConsumerState<LinkAccountCard> {
                       controller: _controller,
                       style: const TextStyle(color: Colors.white),
                       decoration: InputDecoration(
-                        labelText: 'Enter ${widget.platformName} ID',
+                        labelText: widget.inputLabel ?? 'Enter ${widget.platformName} ID',
                         labelStyle: const TextStyle(color: Colors.white70),
                         border: const OutlineInputBorder(),
                       ),

--- a/Mobile/media_tracker_mobile/lib/services/media_api/steam_service.dart
+++ b/Mobile/media_tracker_mobile/lib/services/media_api/steam_service.dart
@@ -22,3 +22,22 @@ Future<List<SteamGame>> fetchSteamGames() async {
     throw Exception('Failed to load Steam games');
   }
 }
+
+Future<Map<String, dynamic>?> fetchSteamAppDetails(String appId) async {
+  try {
+    final response = await http.get(
+      Uri.parse('https://store.steampowered.com/api/appdetails?appids=$appId'),
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      final appData = data[appId];
+      if (appData['success'] == true) {
+        return appData['data'];
+      }
+    }
+  } catch (e) {
+    print('Failed to load Steam app details: $e');
+  }
+  return null;
+}

--- a/Mobile/media_tracker_mobile/lib/services/user_account_services.dart
+++ b/Mobile/media_tracker_mobile/lib/services/user_account_services.dart
@@ -57,12 +57,20 @@ class UserAccountServices {
   // Function to fetch Steam ID from a Vanity username
   Future<String> fetchSteamIDFromVanity(String username) async {
     try {
+      // If input looks like a 64-bit numeric Steam ID, return it directly
+      final isSteamId = RegExp(r'^\d{17}$').hasMatch(username);
+      if (isSteamId) {
+        return username;
+      }
+
+      // Otherwise, treat it as a vanity URL and resolve it using Steam Web API
       final response = await http.get(
         Uri.parse(
           'http://api.steampowered.com/ISteamUser/ResolveVanityURL/v0001/?key=${ApiServices.steamApiKey}&vanityurl=$username',
         ),
       );
 
+      // If resolution was successful, return the resolved Steam ID
       if (response.statusCode == 200) {
         final data = json.decode(response.body);
         if (data['response']['success'] == 1) {


### PR DESCRIPTION
PR created by Sean

- Added logic that allows a user to either enter their Steam ID directly, or a vanity URL (if set up in steam)

- Added custom labels for the account linking screen to make the text fields clearer

- Removed the widget section builders for steam, lastfm, and tmdb into their own files in the subfolder media (lastfm_section.dart, steam_section.dart, and tmdb_section.dart)

- Third party media now links to the media_details_screen to show additional detail for selected media (Only steam functions as of now)

- Added a star icon to denote a favorited piece of media, no functionality as of yet