### PR TITLE
Mobile sean

### DIFF
--- a/Mobile/media_tracker_mobile/lib/screens/media/lastfm_section.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/media/lastfm_section.dart
@@ -1,81 +1,144 @@
 import 'package:flutter/material.dart';
-import 'package:media_tracker_test/models/lastfm/lastfm_top_artist.dart';
+import '../../models/lastfm/lastfm_top_artist.dart';
 import '../../models/lastfm/lastfm_track.dart';
 import '../../models/lastfm/lastfm_user.dart';
+import '../../services/media_api/lastfm_service.dart';
 import '../../screens/media/media_details_screen.dart';
-import '../../services/media_api/lastfm_service.dart'; // Assuming fetchArtistDetail is here
 
-Widget buildLastFmSection(
-  LastFmUser? user,
-  List<TopArtist> topArtists,
-  List<LastFmTrack> recentTracks,
-) {
-  return Builder(
-    builder:
-        (context) => ListView(
-          padding: const EdgeInsets.all(12),
-          children: [
-            if (user != null) ...[
-              Text(
-                "User: ${user.name}",
-                style: const TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              Text("Plays: ${user.playCount}"),
-              const SizedBox(height: 12),
-            ],
-            const Text(
-              "Top Artists",
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+class LastFmSection extends StatelessWidget {
+  final LastFmUser? user;
+  final List<TopArtist> topArtists;
+  final List<LastFmTrack> recentTracks;
+
+  const LastFmSection({
+    super.key,
+    required this.user,
+    required this.topArtists,
+    required this.recentTracks,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const TabBar(
+            tabs: [Tab(text: 'Recent Tracks'), Tab(text: 'Top Artists')],
+            indicatorColor: Colors.grey,
+            labelColor: Colors.white,
+            unselectedLabelColor: Colors.grey,
+          ),
+          Expanded(
+            child: TabBarView(
+              children: [
+                _buildRecentTracksList(),
+                _buildTopArtistsList(context),
+              ],
             ),
-            ...topArtists.map(
-              (artist) => ListTile(
-                title: Text(artist.name),
-                subtitle: Text("Plays: ${artist.playCount}"),
-                onTap: () async {
-                  try {
-                    final details = await fetchArtistDetail(artist.name);
+          ),
+        ],
+      ),
+    );
+  }
 
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder:
-                            (_) => MediaDetailsScreen(
-                              appId: '', // Not needed for Last.fm
-                              title: details.name,
-                              subtitle:
-                                  'Plays: ${details.playCount} • Listeners: ${details.listenerCount}',
-                              mediaType: MediaType.lastfm,
-                              genreIds:
-                                  null, // Could convert tags to something meaningful
-                              releaseDate: '',
-                              posterPath: details.imageUrl,
-                            ),
+  Widget _buildTopArtistsList(BuildContext context) {
+    return ListView.builder(
+      itemCount: topArtists.length,
+      itemBuilder: (context, index) {
+        final artist = topArtists[index];
+        return ListTile(
+          title: Text(artist.name),
+          subtitle: Text("Plays: ${artist.playCount}"),
+          onTap: () async {
+            try {
+              final details = await fetchArtistDetail(artist.name);
+
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder:
+                      (_) => MediaDetailsScreen(
+                        appId: '',
+                        title: details.name,
+                        subtitle:
+                            'Plays: ${details.playCount} • Listeners: ${details.listenerCount}',
+                        mediaType: MediaType.lastfm,
+                        genreIds: null,
+                        releaseDate: '',
+                        posterPath: details.imageUrl,
                       ),
-                    );
-                  } catch (e) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('Failed to load artist details')),
-                    );
-                  }
-                },
-              ),
-            ),
-            const SizedBox(height: 12),
-            const Text(
-              "Recent Tracks",
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-            ),
-            ...recentTracks.map(
-              (track) => ListTile(
-                title: Text(track.name),
-                subtitle: Text("By: ${track.artist}"),
-                trailing: Text(track.formattedDate ?? "Now Playing"),
-              ),
-            ),
-          ],
-        ),
-  );
+                ),
+              );
+            } catch (e) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Failed to load artist details')),
+              );
+            }
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildRecentTracksList() {
+    return ListView.builder(
+      itemCount: recentTracks.length,
+      itemBuilder: (context, index) {
+        final track = recentTracks[index];
+        return ListTile(
+          title: Text(track.name),
+          subtitle: Text("By: ${track.artist}"),
+          trailing: Text(track.formattedDate ?? "Now Playing"),
+          onTap: () async {
+            try {
+              // Fetch album info for this track
+              final albumBasic = await fetchAlbumDetail(
+                track.artist,
+                track.name,
+              );
+
+              if (albumBasic['albumName'] == null) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Album info not found for this track.'),
+                  ),
+                );
+                return;
+              }
+
+              // Fetch full album info
+              final albumDetails = await fetchFullAlbumDetails(
+                track.artist,
+                albumBasic['albumName'],
+              );
+
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder:
+                      (_) => MediaDetailsScreen(
+                        appId: '', // Not needed
+                        title: albumDetails['albumName'],
+                        subtitle: 'Album by ${track.artist}',
+                        mediaType: MediaType.lastfmAlbum,
+                        genreIds: null,
+                        releaseDate: '',
+                        posterPath: albumDetails['albumImageUrl'],
+                        artistName: track.artist,
+                      ),
+                ),
+              );
+            } catch (e) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Failed to load album details')),
+              );
+              print('Failed to load album from track tap: $e');
+            }
+          },
+        );
+      },
+    );
+  }
 }

--- a/Mobile/media_tracker_mobile/lib/screens/media/media_details_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/media/media_details_screen.dart
@@ -8,13 +8,13 @@ enum MediaType { steam, tmdb, lastfm, lastfmAlbum }
 
 class MediaDetailsScreen extends StatefulWidget {
   final String appId; // Required for Steam, optional for TMDB
-  final String title;
-  final String subtitle;
-  final MediaType mediaType;
-  final List<int>? genreIds;
-  final String? releaseDate;
-  final String? posterPath;
-  final String? artistName;
+  final String title; // Title of the media (game name, movie title, artist name, etc.)
+  final String subtitle; // Subtitle text (overview, artist info, etc.)
+  final MediaType mediaType; // Determines what kind of data to show
+  final List<int>? genreIds; // For TMDB movies/shows
+  final String? releaseDate; // Optional release date (for TMDB)
+  final String? posterPath; // Optional poster or album cover path
+  final String? artistName; // Used for Last.fm album drilldown
 
   const MediaDetailsScreen({
     super.key,
@@ -33,8 +33,8 @@ class MediaDetailsScreen extends StatefulWidget {
 }
 
 class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
-  String? _imageUrl;
-  List<String> _extraDetails = [];
+  String? _imageUrl; // URL for media image to display
+  List<String> _extraDetails = []; // List of extra string details
 
   // For Last.fm artist detail
   List<Map<String, dynamic>> _topTracks = [];
@@ -49,6 +49,8 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
   @override
   void initState() {
     super.initState();
+
+    // Determine what to load based on media type
     if (widget.mediaType == MediaType.steam) {
       _loadSteamGameDetails();
     } else if (widget.mediaType == MediaType.tmdb) {
@@ -60,6 +62,7 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
     }
   }
 
+  // Load Steam-specific app details
   Future<void> _loadSteamGameDetails() async {
     final details = await fetchSteamAppDetails(widget.appId);
     if (details != null) {
@@ -75,6 +78,7 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
     }
   }
 
+  // Load TMDB movie/TV show details
   void _loadTmdbDetails() {
     final genres =
         widget.genreIds
@@ -88,12 +92,12 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
         'Release Date: ${widget.releaseDate ?? 'Unknown'}',
         'Description: ${widget.subtitle}',
       ];
-      _imageUrl = null;
+      _imageUrl = null;  // TMDB uses posterPath instead
     });
   }
 
+  // Load Last.fm artist information (top tracks, albums, similar artists)
   Future<void> _loadLastFmDetails() async {
-    // Details already passed in subtitle/title from the listtile, just load extra sections
     try {
       final topTracks = await fetchArtistTopTracks(widget.title);
       final topAlbums = await fetchArtistTopAlbums(widget.title);
@@ -109,6 +113,7 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
     }
   }
 
+  // Load Last.fm album details (tracklist, album image, durations)
   Future<void> _loadLastFmAlbumDetails() async {
     try {
       final albumDetails = await fetchFullAlbumDetails(
@@ -137,6 +142,7 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
     }
   }
 
+  // Resolve the correct image URL based on media type
   String _resolveImageUrl() {
     if (widget.mediaType == MediaType.lastfm) {
       return ''; // No image for Last.fm artists
@@ -151,10 +157,12 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
     return 'https://via.placeholder.com/300x400?text=No+Image';
   }
 
+  // Format genres for TMDB movies and tv shows
   String _formatGenres(List<dynamic>? genres) {
     return genres?.map((g) => g['description']).join(', ') ?? 'Unknown';
   }
 
+  // Format number with thousands separator
   String formatNumber(int number) {
     final formatter = NumberFormat.decimalPattern();
     return formatter.format(number);
@@ -187,6 +195,8 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
               ),
 
             const SizedBox(height: 16),
+
+            // Show extra details
             ..._extraDetails.map(
               (detail) => Padding(
                 padding: const EdgeInsets.only(bottom: 8.0),
@@ -197,6 +207,7 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
               ),
             ),
 
+            // Last.fm Artist Detail Screen
             if (widget.mediaType == MediaType.lastfm) ...[
               if (_topTracks.isNotEmpty) _buildSectionTitle('Top Tracks'),
               ...(_showAllTracks ? _topTracks.take(10) : _topTracks.take(5)).map(
@@ -265,6 +276,7 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
                 ),
             ],
             
+            // Last.fm Album Detail Screen
             if (widget.mediaType == MediaType.lastfmAlbum) ...[
                 if (_topTracks.isNotEmpty) _buildSectionTitle('Tracklist'),
                 ListView.separated(
@@ -298,6 +310,7 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
     );
   }
 
+  // Helper to build section titles
   Widget _buildSectionTitle(String title) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8.0),
@@ -308,6 +321,7 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
     );
   }
 
+  // Format seconds into mm:ss
   String _formatDuration(int seconds) {
     final minutes = seconds ~/ 60;
     final remainingSeconds = seconds % 60;

--- a/Mobile/media_tracker_mobile/lib/screens/media/media_details_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/media/media_details_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:media_tracker_test/services/media_api/lastfm_service.dart';
 import '../../models/tmdb/genre_helper.dart';
 import '../../services/media_api/steam_service.dart';
+import 'package:intl/intl.dart';
 
-enum MediaType { steam, tmdb, lastfm }
+enum MediaType { steam, tmdb, lastfm, lastfmAlbum }
 
 class MediaDetailsScreen extends StatefulWidget {
   final String appId; // Required for Steam, optional for TMDB
@@ -12,6 +14,7 @@ class MediaDetailsScreen extends StatefulWidget {
   final List<int>? genreIds;
   final String? releaseDate;
   final String? posterPath;
+  final String? artistName;
 
   const MediaDetailsScreen({
     super.key,
@@ -22,6 +25,7 @@ class MediaDetailsScreen extends StatefulWidget {
     this.genreIds,
     this.releaseDate,
     this.posterPath,
+    this.artistName,
   });
 
   @override
@@ -32,13 +36,27 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
   String? _imageUrl;
   List<String> _extraDetails = [];
 
+  // For Last.fm artist detail
+  List<Map<String, dynamic>> _topTracks = [];
+  List<Map<String, dynamic>> _topAlbums = [];
+  List<Map<String, dynamic>> _similarArtists = [];
+
+  // Expansion booleans for artist detail
+  bool _showAllTracks = false;
+  bool _showAllAlbums = false;
+  bool _showAllSimilarArtists = false;
+
   @override
   void initState() {
     super.initState();
     if (widget.mediaType == MediaType.steam) {
       _loadSteamGameDetails();
-    } else {
+    } else if (widget.mediaType == MediaType.tmdb) {
       _loadTmdbDetails();
+    } else if (widget.mediaType == MediaType.lastfm) {
+      _loadLastFmDetails();
+    } else if (widget.mediaType == MediaType.lastfmAlbum) {
+      _loadLastFmAlbumDetails();
     }
   }
 
@@ -74,19 +92,62 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
     });
   }
 
+  Future<void> _loadLastFmDetails() async {
+    // Details already passed in subtitle/title from the listtile, just load extra sections
+    try {
+      final topTracks = await fetchArtistTopTracks(widget.title);
+      final topAlbums = await fetchArtistTopAlbums(widget.title);
+      final similarArtists = await fetchSimilarArtists(widget.title);
+
+      setState(() {
+        _topTracks = topTracks;
+        _topAlbums = topAlbums;
+        _similarArtists = similarArtists;
+      });
+    } catch (e) {
+      print('Failed to load extra last.fm details: $e');
+    }
+  }
+
+  Future<void> _loadLastFmAlbumDetails() async {
+    try {
+      final albumDetails = await fetchFullAlbumDetails(
+        widget.artistName ?? '',
+        widget.title,
+      );
+
+      // Load tracks, calculate total album duration
+      final tracks = albumDetails['tracks'] as List<Map<String, dynamic>>;
+      final totalSeconds = tracks.fold<int>(
+        0,
+        (sum, track) => sum + ((track['duration'] ?? 0) as int),
+      );
+      final totalMinutes = (totalSeconds / 60).round();
+
+      setState(() {
+        _extraDetails = [
+          'Total Album Length: $totalMinutes minutes',
+          'Tracks: ${tracks.length}',
+        ];
+        _topTracks = tracks;
+        _imageUrl = albumDetails['albumImageUrl'];
+      });
+    } catch (e) {
+      print('Failed to load Last.fm album details: $e');
+    }
+  }
+
   String _resolveImageUrl() {
+    if (widget.mediaType == MediaType.lastfm) {
+      return ''; // No image for Last.fm artists
+    }
+
     if (_imageUrl != null) return _imageUrl!;
 
     if (widget.mediaType == MediaType.tmdb && widget.posterPath != null) {
       return 'https://image.tmdb.org/t/p/w500${widget.posterPath}';
     }
 
-    if (widget.mediaType == MediaType.lastfm && widget.posterPath != null) {
-      print(widget.posterPath!);
-      return widget.posterPath!;
-    }
-
-    // Fallback image if none are provided
     return 'https://via.placeholder.com/300x400?text=No+Image';
   }
 
@@ -94,8 +155,14 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
     return genres?.map((g) => g['description']).join(', ') ?? 'Unknown';
   }
 
+  String formatNumber(int number) {
+    final formatter = NumberFormat.decimalPattern();
+    return formatter.format(number);
+  }
+
   @override
   Widget build(BuildContext context) {
+    final imageUrl = _resolveImageUrl();
     return Scaffold(
       appBar: AppBar(title: Text(widget.title)),
       body: SingleChildScrollView(
@@ -103,17 +170,19 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (_imageUrl != null || widget.posterPath != null)
+            if (imageUrl.isNotEmpty)
               Center(
                 child: Image.network(
-                  _resolveImageUrl(),
+                  imageUrl,
                   fit: BoxFit.cover,
                   height:
                       widget.mediaType == MediaType.steam
                           ? 200
                           : widget.mediaType == MediaType.tmdb
                           ? 500
-                          : 300, // last.fm
+                          : widget.mediaType == MediaType.lastfmAlbum
+                          ? 300 // Album Images
+                          : 400, // Default fallback height
                 ),
               ),
 
@@ -127,9 +196,122 @@ class _MediaDetailsScreenState extends State<MediaDetailsScreen> {
                 ),
               ),
             ),
+
+            if (widget.mediaType == MediaType.lastfm) ...[
+              if (_topTracks.isNotEmpty) _buildSectionTitle('Top Tracks'),
+              ...(_showAllTracks ? _topTracks.take(10) : _topTracks.take(5)).map(
+                (track) => ListTile(
+                  title: Text(track['name']),
+                  subtitle: Text(
+                    'Playcount: ${formatNumber(int.parse(track['playcount']))}',
+                  ),
+                ),
+              ),
+              if (_topTracks.length > 5)
+                TextButton(
+                  onPressed: () {
+                    setState(() {
+                      _showAllTracks = !_showAllTracks;
+                    });
+                  },
+                  child: Text(_showAllTracks ? 'Show Less' : 'Show More'),
+                ),
+
+              const SizedBox(height: 24),
+              if (_topAlbums.isNotEmpty) _buildSectionTitle('Top Albums'),
+              ...(_showAllAlbums ? _topAlbums.take(10) : _topAlbums.take(5))
+                  .map(
+                    (album) => ListTile(
+                      leading:
+                          album['imageUrl'] != null
+                              ? Image.network(
+                                album['imageUrl'],
+                                width: 50,
+                                height: 50,
+                                fit: BoxFit.cover,
+                              )
+                              : null,
+                      title: Text(album['name']),
+                      subtitle: Text('Playcount: ${album['playcount']}'),
+                    ),
+                  ),
+              if (_topAlbums.length > 5)
+                TextButton(
+                  onPressed: () {
+                    setState(() {
+                      _showAllAlbums = !_showAllAlbums;
+                    });
+                  },
+                  child: Text(_showAllAlbums ? 'Show Less' : 'Show More'),
+                ),
+
+              const SizedBox(height: 24),
+              if (_similarArtists.isNotEmpty)
+                _buildSectionTitle('Similar Artists'),
+              ...(_showAllSimilarArtists
+                      ? _similarArtists.take(10)
+                      : _similarArtists.take(5))
+                  .map((artist) => ListTile(title: Text(artist['name']))),
+              if (_similarArtists.length > 5)
+                TextButton(
+                  onPressed: () {
+                    setState(() {
+                      _showAllSimilarArtists = !_showAllSimilarArtists;
+                    });
+                  },
+                  child: Text(
+                    _showAllSimilarArtists ? 'Show Less' : 'Show More',
+                  ),
+                ),
+            ],
+            
+            if (widget.mediaType == MediaType.lastfmAlbum) ...[
+                if (_topTracks.isNotEmpty) _buildSectionTitle('Tracklist'),
+                ListView.separated(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: _topTracks.length,
+                  separatorBuilder:
+                      (context, index) => const Divider(height: 1),
+                  itemBuilder: (context, index) {
+                    final track = _topTracks[index];
+                    final trackNumber = index + 1;
+                    final trackName = track['name'] ?? 'Unknown';
+                    final durationSeconds = track['duration'] ?? 0;
+
+                    return ListTile(
+                      leading: Text(
+                        '$trackNumber.',
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      title: Text(trackName),
+                      subtitle: Text(
+                        'Duration: ${_formatDuration(durationSeconds)}',
+                      ),
+                    );
+                  },
+                ),
+              ],
           ],
         ),
       ),
     );
+  }
+
+  Widget _buildSectionTitle(String title) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Text(
+        title,
+        style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+
+  String _formatDuration(int seconds) {
+    final minutes = seconds ~/ 60;
+    final remainingSeconds = seconds % 60;
+    final twoDigits = remainingSeconds.toString().padLeft(2, '0');
+    return '$minutes:$twoDigits';
   }
 }

--- a/Mobile/media_tracker_mobile/lib/screens/media/media_screen.dart
+++ b/Mobile/media_tracker_mobile/lib/screens/media/media_screen.dart
@@ -214,7 +214,11 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
       case 1:
         if (_isLoadingLastFm) return _loading();
         if (auth.lastFmUsername == null) return _noMediaLinkedPrompt("Last.fm");
-        return buildLastFmSection(_lastFmUser, _topArtists, _recentTracks);
+        return LastFmSection(
+          user: _lastFmUser,
+          topArtists: _topArtists,
+          recentTracks: _recentTracks,
+        );
       case 2:
         if (_isLoadingTmdb) return _loading();
         if (auth.tmdbSessionId == null) return _noMediaLinkedPrompt("TMDB");

--- a/Mobile/media_tracker_mobile/lib/services/media_api/lastfm_service.dart
+++ b/Mobile/media_tracker_mobile/lib/services/media_api/lastfm_service.dart
@@ -6,6 +6,7 @@ import '../../models/lastfm/lastfm_artist.dart';
 import '../../models/lastfm/lastfm_track.dart';
 import '/config/api_connections.dart';
 
+// User information
 Future<LastFmUser> fetchLastFmUser() async {
   final url =
       '${ApiServices.lastFmBaseUrl}?method=user.getinfo'
@@ -40,23 +41,6 @@ Future<List<TopArtist>> fetchLastFmTopArtists() async {
   }
 }
 
-Future<LastFmArtist> fetchArtistDetail(String artistName) async {
-  final url =
-      'http://ws.audioscrobbler.com/2.0/?method=artist.getinfo'
-      '&artist=${Uri.encodeComponent(artistName)}'
-      '&api_key=${ApiServices.lastFmApiKey}'
-      '&format=json';
-
-  final response = await http.get(Uri.parse(url));
-
-  if (response.statusCode == 200) {
-    final data = jsonDecode(response.body);
-    return LastFmArtist.fromJson(data);
-  } else {
-    throw Exception('Failed to fetch artist\'s detail.');
-  }
-}
-
 Future<List<LastFmTrack>> fetchLastFmRecentTracks() async {
   final url =
       '${ApiServices.lastFmBaseUrl}?method=user.getrecenttracks'
@@ -72,5 +56,213 @@ Future<List<LastFmTrack>> fetchLastFmRecentTracks() async {
     return tracks.map((json) => LastFmTrack.fromJson(json)).toList();
   } else {
     throw Exception('Failed to fetch recent tracks');
+  }
+}
+
+// Artist information
+Future<LastFmArtist> fetchArtistDetail(String artistName) async {
+  final url =
+      'http://ws.audioscrobbler.com/2.0/?method=artist.getinfo'
+      '&artist=${Uri.encodeComponent(artistName)}'
+      '&api_key=${ApiServices.lastFmApiKey}'
+      '&format=json';
+
+  final response = await http.get(Uri.parse(url));
+
+  if (response.statusCode == 200) {
+    final data = jsonDecode(response.body);
+    print(jsonEncode(data));
+    return LastFmArtist.fromJson(data);
+  } else {
+    throw Exception('Failed to fetch artist\'s detail.');
+  }
+}
+
+// Artist top tracks
+Future<List<Map<String, dynamic>>> fetchArtistTopTracks(
+  String artistName,
+) async {
+  final url =
+      'http://ws.audioscrobbler.com/2.0/?method=artist.gettoptracks'
+      '&artist=${Uri.encodeComponent(artistName)}'
+      '&api_key=${ApiServices.lastFmApiKey}'
+      '&format=json';
+
+  final response = await http.get(Uri.parse(url));
+
+  if (response.statusCode == 200) {
+    final data = jsonDecode(response.body);
+    print(jsonEncode(data)); // DEBUGGING
+
+    final tracks =
+        (data['toptracks']['track'] as List)
+            .map(
+              (track) => {
+                'name': track['name'],
+                'playcount': track['playcount'],
+                'url': track['url'],
+              },
+            )
+            .toList();
+
+    return tracks;
+  } else {
+    throw Exception('Failed to fetch artist\'s top tracks.');
+  }
+}
+
+// Artist top albums
+Future<List<Map<String, dynamic>>> fetchArtistTopAlbums(
+  String artistName,
+) async {
+  final url =
+      'http://ws.audioscrobbler.com/2.0/?method=artist.gettopalbums'
+      '&artist=${Uri.encodeComponent(artistName)}'
+      '&api_key=${ApiServices.lastFmApiKey}'
+      '&format=json';
+
+  final response = await http.get(Uri.parse(url));
+
+  if (response.statusCode == 200) {
+    final data = jsonDecode(response.body);
+    print(jsonEncode(data)); // DEBUGGING
+
+    final albums =
+        (data['topalbums']['album'] as List)
+            .map(
+              (album) => {
+                'name': album['name'],
+                'playcount': album['playcount'],
+                'imageUrl':
+                    album['image'] != null && album['image'].length > 2
+                        ? album['image'][2]['#text']
+                        : null,
+              },
+            )
+            .toList();
+
+    return albums;
+  } else {
+    throw Exception('Failed to fetch artist\'s top albums.');
+  }
+}
+
+// Similar artists
+Future<List<Map<String, dynamic>>> fetchSimilarArtists(
+  String artistName,
+) async {
+  final url =
+      'http://ws.audioscrobbler.com/2.0/?method=artist.getsimilar'
+      '&artist=${Uri.encodeComponent(artistName)}'
+      '&api_key=${ApiServices.lastFmApiKey}'
+      '&format=json';
+
+  final response = await http.get(Uri.parse(url));
+
+  if (response.statusCode == 200) {
+    final data = jsonDecode(response.body);
+    print(jsonEncode(data)); // DEBUGGING
+
+    final artists =
+        (data['similarartists']['artist'] as List)
+            .map(
+              (artist) => {
+                'name': artist['name'],
+                'match': artist['match'],
+                'imageUrl':
+                    artist['image'] != null && artist['image'].length > 2
+                        ? artist['image'][2]['#text']
+                        : null,
+              },
+            )
+            .toList();
+
+    return artists;
+  } else {
+    throw Exception('Failed to fetch similar artists.');
+  }
+}
+
+// Fetch album details
+Future<Map<String, dynamic>> fetchAlbumDetail(
+  String artistName,
+  String trackName,
+) async {
+  final url =
+      'http://ws.audioscrobbler.com/2.0/?method=track.getInfo'
+      '&artist=${Uri.encodeComponent(artistName)}'
+      '&track=${Uri.encodeComponent(trackName)}'
+      '&api_key=${ApiServices.lastFmApiKey}'
+      '&format=json';
+
+  final response = await http.get(Uri.parse(url));
+
+  if (response.statusCode == 200) {
+    final data = jsonDecode(response.body);
+    print(jsonEncode(data)); // DEBUGGING
+
+    final albumData = data['track']?['album'];
+    if (albumData == null) throw Exception('Album info not found for track.');
+
+    return {
+      'albumName': albumData['title'],
+      'albumImageUrl':
+          albumData['image'] != null && albumData['image'].length > 2
+              ? albumData['image'][2]['#text'] // medium size
+              : null,
+    };
+  } else {
+    throw Exception('Failed to fetch track/album info.');
+  }
+}
+
+// Fetch full album details from the album name
+Future<Map<String, dynamic>> fetchFullAlbumDetails(String artistName, String albumName) async {
+  final url =
+      'http://ws.audioscrobbler.com/2.0/?method=album.getinfo'
+      '&artist=${Uri.encodeComponent(artistName)}'
+      '&album=${Uri.encodeComponent(albumName)}'
+      '&api_key=${ApiServices.lastFmApiKey}'
+      '&format=json';
+
+  final response = await http.get(Uri.parse(url));
+
+  if (response.statusCode == 200) {
+    final data = jsonDecode(response.body);
+    final album = data['album'];
+
+    final rawTracks = album['tracks']['track'];
+
+    List<Map<String, dynamic>> tracks = [];
+
+    if (rawTracks is List) {
+      // Normal multiple tracks
+      tracks = rawTracks.map<Map<String, dynamic>>((track) {
+        return {
+          'name': track['name'],
+          'duration': int.tryParse('${track['duration'] ?? '0'}') ?? 0,
+          'playcount': '${track['playcount'] ?? 'Unknown'}',
+        };
+      }).toList();
+    } else if (rawTracks is Map) {
+      // Only one track (special case)
+      tracks = [
+        {
+          'name': rawTracks['name'],
+          'duration': int.tryParse('${rawTracks['duration'] ?? '0'}') ?? 0,
+          'playcount': '${rawTracks['playcount'] ?? 'Unknown'}',
+        }
+      ];
+    }
+
+    return {
+      'albumName': album['name'],
+      'albumImageUrl': album['image'] != null && album['image'].length > 2
+          ? album['image'][2]['#text']
+          : null,
+      'tracks': tracks,
+    };
+  } else {
+    throw Exception('Failed to fetch full album info.');
   }
 }

--- a/Mobile/media_tracker_mobile/pubspec.lock
+++ b/Mobile/media_tracker_mobile/pubspec.lock
@@ -192,6 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   jwt_decode:
     dependency: transitive
     description:

--- a/Mobile/media_tracker_mobile/pubspec.yaml
+++ b/Mobile/media_tracker_mobile/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   #This is for the bycryp package
   bcrypt: ^1.1.3
   url_launcher: ^6.3.1
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
PR created by Sean

- Last fm data is now displayed in a tab view much like TMDB with recent tracks and top artist displayed at the top.

- Each recent song is a tappable list tile that will navigate to the media_details_screen to display expanded information about what album that song belongs too along with album duration, album image, and track lists with durations

- The top artists are also tappable list tiles that will navigate the user to the media_details_screen to show more detailed information about the artist

- Added some comments for clarity